### PR TITLE
Change license abbreviation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Use icons prefixed with `dmn-icon-`, i.e.:
 
 ## License
 
-[SIL](http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web)
+[OFL](http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web)


### PR DESCRIPTION
SIL is the organization that created the license. OFL is used as the abbreviation at http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web.

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
